### PR TITLE
Fix bug when one of the limits is zero which evaluates to false

### DIFF
--- a/render_list_geo.pl
+++ b/render_list_geo.pl
@@ -21,9 +21,12 @@ if ($options->{h}) {
 
 my ($z, $Z);
 my $bulkSize=8;
-if ($options->{x} && $options->{X} &&
-    $options->{y} && $options->{Y} &&
-    $options->{z} && $options->{Z})
+if (($options->{x} || $options->{x}==0) &&
+    ($options->{X} || $options->{X}==0) &&
+    ($options->{y} || $options->{y}==0) && 
+    ($options->{Y} || $options->{Y}==0) &&
+    ($options->{z} || $options->{z}==0) && 
+    ($options->{Z} || $options->{Z}==0))
 {
     print "\nRendering started at: ";
     system("date");


### PR DESCRIPTION
If one of the arguments is zero then if (argument) evaluates to false, even though zero is an acceptable value for it. Done a very simple thing and allowed zero for all the options in the if statement. Fixes #4.
